### PR TITLE
Fix broken type hints

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,3 +64,18 @@ repos:
       - id: bandit
         name: bandit
         args: ["-c", ".bandit"]
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.17.1
+    hooks:
+      - id: mypy
+        name: mypy
+        args: []
+        additional_dependencies:
+          [
+            "types-jsonschema",
+            "types-tqdm",
+            "types-tabulate",
+            "scipy-stubs",
+            "matplotlib", # There are no official stubs for matplotlib
+          ]

--- a/codebasin/__init__.py
+++ b/codebasin/__init__.py
@@ -1,8 +1,11 @@
 # Copyright (C) 2019-2024 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
 import importlib.metadata
 import os
 import shlex
+import typing
 import warnings
 from collections.abc import Iterable
 from pathlib import Path
@@ -152,7 +155,7 @@ class CompilationDatabase:
         yield from self.commands
 
     @classmethod
-    def from_json(cls, instance: list):
+    def from_json(cls, instance: list) -> CompilationDatabase:
         """
         Parameters
         ----------
@@ -174,7 +177,10 @@ class CompilationDatabase:
         return cls(commands)
 
     @classmethod
-    def from_file(cls, filename: str | os.PathLike[str]):
+    def from_file(
+        cls,
+        filename: str | os.PathLike[str],
+    ) -> CompilationDatabase:
         """
         Parameters
         ---------
@@ -194,8 +200,8 @@ class CompilationDatabase:
             A CompilationDatbase corresponding to the provided JSON file.
         """
         with open(filename) as f:
-            db = codebasin.util._load_json(f, schema_name="compiledb")
-        return CompilationDatabase.from_json(db)
+            db: object = codebasin.util._load_json(f, schema_name="compiledb")
+        return CompilationDatabase.from_json(typing.cast(list, db))
 
 
 class CodeBase:

--- a/codebasin/__main__.py
+++ b/codebasin/__main__.py
@@ -44,10 +44,10 @@ def _help_string(*lines: str, is_long=False, is_last=False):
 
     # argparse.HelpFormatter indents by 24 characters.
     # We cannot override this directly, but can delete them with backspaces.
-    lines = ["\b" * 20 + x for x in lines]
+    modified_lines = ["\b" * 20 + x for x in lines]
 
     # The additional space is required for argparse to respect newlines.
-    result += "\n".join(lines)
+    result += "\n".join(modified_lines)
 
     if not is_last:
         result += "\n "

--- a/codebasin/coverage/__main__.py
+++ b/codebasin/coverage/__main__.py
@@ -128,11 +128,13 @@ def _compute(args: argparse.Namespace):
         with open(filename, "rb") as f:
             digest = hashlib.file_digest(f, "sha512")
 
-        used_lines = []
-        unused_lines = []
+        used_lines: list[int] = []
+        unused_lines: list[int] = []
         tree = state.get_tree(filename)
         association = state.get_map(filename)
         for node in [n for n in tree.walk() if isinstance(n, CodeNode)]:
+            if not node.lines:
+                continue
             if association[node] == frozenset([]):
                 unused_lines.extend(node.lines)
             else:

--- a/codebasin/finder.py
+++ b/codebasin/finder.py
@@ -96,7 +96,7 @@ class ParserState:
         dict[frozenset, int]
             The number of lines associated with each platform set.
         """
-        setmap = collections.defaultdict(int)
+        setmap: dict[frozenset, int] = collections.defaultdict(int)
         for fn in codebase:
             # Don't count symlinks if their target is in the code base.
             # The target will be counted separately.

--- a/codebasin/preprocessor.py
+++ b/codebasin/preprocessor.py
@@ -620,7 +620,7 @@ class CodeNode(Node):
     end_line: int = field(default=-1, init=False)
     num_lines: int = field(default=0, init=False)
     source: str | None = field(default=None, init=False, repr=False)
-    lines: list[str] | None = field(
+    lines: list[int] | None = field(
         default_factory=list,
         init=False,
         repr=False,

--- a/codebasin/util.py
+++ b/codebasin/util.py
@@ -95,12 +95,12 @@ def valid_path(path: os.PathLike[str]) -> bool:
     valid = True
 
     # Check for null byte character(s)
-    if "\x00" in path:
+    if "\x00" in str(path):
         log.critical("Null byte character in file request.")
         valid = False
 
     # Check for carriage returns or line feed character(s)
-    if ("\n" in path) or ("\r" in path):
+    if ("\n" in str(path)) or ("\r" in str(path)):
         log.critical("Carriage return or line feed character in file request.")
         valid = False
 
@@ -223,7 +223,7 @@ def _load_json(file_object: typing.TextIO, schema_name: str) -> object:
 
 
 def _load_toml(
-    file_object: typing.TextIO,
+    file_object: typing.IO,
     schema_name: str,
 ) -> dict[str, typing.Any]:
     """
@@ -231,7 +231,7 @@ def _load_toml(
 
     Parameters
     ----------
-    file_object : typing.TextIO
+    file_object : typing.IO
         The file object to load from.
 
     schema_name : {'cbiconfig', 'analysis'}

--- a/codebasin/util.py
+++ b/codebasin/util.py
@@ -21,7 +21,10 @@ import jsonschema
 log = logging.getLogger(__name__)
 
 
-def ensure_ext(path: os.PathLike[str], extensions: Iterable[str]) -> None:
+def ensure_ext(
+    path: str | os.PathLike[str],
+    extensions: Iterable[str],
+) -> None:
     """
     Ensure that a path has one of the specified extensions.
 
@@ -54,7 +57,7 @@ def ensure_ext(path: os.PathLike[str], extensions: Iterable[str]) -> None:
         raise ValueError(f"{path} does not have a valid extension: {exts}")
 
 
-def safe_open_write_binary(fname: os.PathLike[str]) -> typing.BinaryIO:
+def safe_open_write_binary(fname: str | os.PathLike[str]) -> typing.BinaryIO:
     """Open fname for (binary) writing. Truncate if not a symlink."""
     fpid = os.open(
         fname,
@@ -64,7 +67,7 @@ def safe_open_write_binary(fname: os.PathLike[str]) -> typing.BinaryIO:
     return os.fdopen(fpid, "wb")
 
 
-def valid_path(path: os.PathLike[str]) -> bool:
+def valid_path(path: str | os.PathLike[str]) -> bool:
     """
     Check if a given file path is valid.
 
@@ -74,7 +77,7 @@ def valid_path(path: os.PathLike[str]) -> bool:
 
     Parameters
     ----------
-    path : os.PathLike[str]
+    path : str | os.PathLike[str]
         The file path to be validated.
 
     Returns


### PR DESCRIPTION
# Related issues

- #182 

# Proposed changes

<!--
List out, with high level descriptions, what the commits within this pull
request do.
-->

- Fix errors reported by `mypy` due to broken or inconsistent type hints.
- Fix a few minor bugs and/or confusing patterns caused by variables redefined with a new type.
- Add `mypy` to GitHub Actions to ensure that we don't introduce any new broken type hints.
