### PR TITLE
Add missing type hints

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,7 +70,7 @@ repos:
     hooks:
       - id: mypy
         name: mypy
-        args: []
+        args: ["--disallow-untyped-defs"]
         additional_dependencies:
           [
             "types-jsonschema",
@@ -79,3 +79,4 @@ repos:
             "scipy-stubs",
             "matplotlib", # There are no official stubs for matplotlib
           ]
+        exclude: "^tests/"

--- a/codebasin/__init__.py
+++ b/codebasin/__init__.py
@@ -155,7 +155,7 @@ class CompilationDatabase:
     def __init__(self, commands: list[CompileCommand]):
         self.commands = commands
 
-    def __iter__(self) -> Generator[CompileCommand]:
+    def __iter__(self) -> Generator[CompileCommand, None, None]:
         """
         Iterate over all commands in the compilation database.
         """
@@ -310,7 +310,7 @@ class CodeBase:
 
         return True
 
-    def __iter__(self) -> Generator[str]:
+    def __iter__(self) -> Generator[str, None, None]:
         """
         Iterate over all files in the code base by walking each directory.
         """

--- a/codebasin/__init__.py
+++ b/codebasin/__init__.py
@@ -7,7 +7,7 @@ import os
 import shlex
 import typing
 import warnings
-from collections.abc import Iterable
+from collections.abc import Generator, Iterable
 from pathlib import Path
 
 import pathspec
@@ -41,6 +41,9 @@ class CompileCommand:
     arguments: list[string], optional
         The `argv` for this command, including the executable as `argv[0]`.
 
+    command: string, optional
+        The command as a string.
+
     output: string, optional
         The name of the file produced by this command, or None if not
         specified.
@@ -48,12 +51,12 @@ class CompileCommand:
 
     def __init__(
         self,
-        filename,
-        directory=None,
-        arguments=None,
-        command=None,
-        output=None,
-    ):
+        filename: str,
+        directory: str | None = None,
+        arguments: list[str] | None = None,
+        command: str | None = None,
+        output: str | None = None,
+    ) -> None:
         """
         Raises
         ------
@@ -69,35 +72,39 @@ class CompileCommand:
         self._output = output
 
     @property
-    def directory(self):
+    def directory(self) -> str | None:
         return self._directory
 
     @property
-    def filename(self):
+    def filename(self) -> str:
         return self._filename
 
     @property
-    def arguments(self):
+    def arguments(self) -> list[str]:
         if self._arguments is None:
-            return shlex.split(self._command)
+            if self._command is not None:
+                return shlex.split(self._command)
+            else:
+                raise ValueError(
+                    "CompileCommand requires arguments or command.",
+                )
         else:
             return self._arguments
 
     @property
-    def output(self):
+    def output(self) -> str | None:
         return self._output
 
-    def __str__(self):
-        if self._command is None:
-            return " ".join(self._arguments)
-        else:
-            return self._command
+    def __str__(self) -> str:
+        return " ".join(self.arguments)
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, CompileCommand):
+            return NotImplemented
         props = ["directory", "filename", "arguments", "output"]
         return all([getattr(self, p) == getattr(other, p) for p in props])
 
-    def is_supported(self):
+    def is_supported(self) -> bool:
         """
         Returns
         -------
@@ -115,7 +122,7 @@ class CompileCommand:
         return False
 
     @classmethod
-    def from_json(cls, instance: dict):
+    def from_json(cls, instance: dict) -> CompileCommand:
         """
         Parameters
         ----------
@@ -148,7 +155,7 @@ class CompilationDatabase:
     def __init__(self, commands: list[CompileCommand]):
         self.commands = commands
 
-    def __iter__(self):
+    def __iter__(self) -> Generator[CompileCommand]:
         """
         Iterate over all commands in the compilation database.
         """
@@ -220,7 +227,7 @@ class CodeBase:
     def __init__(
         self,
         *directories: str | os.PathLike[str],
-        exclude_patterns: Iterable[str] = [],
+        exclude_patterns: list[str] = [],
     ):
         """
         Raises
@@ -242,18 +249,18 @@ class CodeBase:
         self._directories = [Path(d).resolve() for d in directories]
         self._excludes = exclude_patterns
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f"CodeBase(directories={self.directories}, "
             + f"exclude_patterns={self.exclude_patterns})"
         )
 
     @property
-    def directories(self):
+    def directories(self) -> list[str]:
         return [str(d) for d in self._directories]
 
     @property
-    def exclude_patterns(self):
+    def exclude_patterns(self) -> list[str]:
         return self._excludes
 
     def __contains__(self, path: os.PathLike) -> bool:
@@ -303,7 +310,7 @@ class CodeBase:
 
         return True
 
-    def __iter__(self):
+    def __iter__(self) -> Generator[str]:
         """
         Iterate over all files in the code base by walking each directory.
         """

--- a/codebasin/__main__.py
+++ b/codebasin/__main__.py
@@ -18,7 +18,11 @@ log = logging.getLogger("codebasin")
 _traceback = False
 
 
-def _help_string(*lines: str, is_long=False, is_last=False):
+def _help_string(
+    *lines: str,
+    is_long: bool = False,
+    is_last: bool = False,
+) -> str:
     """
     Parameters
     ----------
@@ -55,7 +59,7 @@ def _help_string(*lines: str, is_long=False, is_last=False):
     return result
 
 
-def _main():
+def _main() -> None:
     # Read command-line arguments
     parser = argparse.ArgumentParser(
         description="Code Base Investigator " + str(__version__),
@@ -260,7 +264,7 @@ def _main():
     # Count lines for platforms
     setmap = state.get_setmap(codebase)
 
-    def report_enabled(name):
+    def report_enabled(name: str) -> bool:
         if "all" in args.reports or len(args.reports) == 0:
             return True
         return name in args.reports
@@ -285,7 +289,7 @@ def _main():
     sys.exit(0)
 
 
-def main():
+def main() -> None:
     try:
         _main()
     except Exception as e:

--- a/codebasin/_detail/logging.py
+++ b/codebasin/_detail/logging.py
@@ -111,7 +111,7 @@ class MetaWarning:
             return True
         return False
 
-    def warn(self, logger: logging.Logger):
+    def warn(self, logger: logging.Logger) -> None:
         """
         Produce the warning associated with this MetaWarning.
 
@@ -133,7 +133,7 @@ class WarningAggregator(logging.Filter):
     warning passing through a logger.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.meta_warnings = [
             MetaWarning(".", "{} warnings generated during preprocessing."),
             MetaWarning(
@@ -176,7 +176,7 @@ class WarningAggregator(logging.Filter):
                 meta_warning.inspect(record)
         return True
 
-    def warn(self, logger: logging.Logger):
+    def warn(self, logger: logging.Logger) -> None:
         """
         Produce the warning associated with any MetaWarning(s) that were
         matched by this WarningAggregator.

--- a/codebasin/coverage/__main__.py
+++ b/codebasin/coverage/__main__.py
@@ -102,7 +102,7 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _compute(args: argparse.Namespace):
+def _compute(args: argparse.Namespace) -> None:
     dbpath = os.path.realpath(args.ifile)
     covpath = os.path.realpath(args.ofile)
     for path in [dbpath, covpath]:
@@ -156,7 +156,7 @@ def _compute(args: argparse.Namespace):
     sys.exit(0)
 
 
-def cli(argv: list[str]) -> int:
+def cli(argv: list[str]) -> None:
     parser = _build_parser()
     args = parser.parse_args(argv)
     command = args.func
@@ -188,10 +188,10 @@ def cli(argv: list[str]) -> int:
     stderr_handler.setFormatter(Formatter(colors=sys.stderr.isatty()))
     log.addHandler(stderr_handler)
 
-    return command(args)
+    command(args)
 
 
-def main():
+def main() -> None:
     try:
         cli(sys.argv[1:])
     except Exception as e:

--- a/codebasin/coverage/__main__.py
+++ b/codebasin/coverage/__main__.py
@@ -132,6 +132,8 @@ def _compute(args: argparse.Namespace) -> None:
         unused_lines: list[int] = []
         tree = state.get_tree(filename)
         association = state.get_map(filename)
+        if tree is None or association is None:
+            raise RuntimeError(f"Missing tree or association for {'filename'}")
         for node in [n for n in tree.walk() if isinstance(n, CodeNode)]:
             if not node.lines:
                 continue

--- a/codebasin/file_source.py
+++ b/codebasin/file_source.py
@@ -463,7 +463,6 @@ class line_info:
 
 def c_file_source(
     fp: TextIO,
-    *,
     directives_only: bool = False,
 ) -> Generator[line_info, None, tuple[int, int]]:
     """
@@ -709,14 +708,12 @@ def asm_file_source(fp: TextIO) -> Generator[line_info, None, tuple[int, int]]:
     return (total_sloc, total_physical_lines)
 
 
-# FIXME: The return type of this function suggests it is too complicated.
+# FIXME: Specifying the return type of this function precisely is too hard,
+#        suggesting it is too complicated.
 def get_file_source(
     path: str,
     assumed_lang: str | None = None,
-) -> (
-    Callable[[TextIO], Generator[line_info, None, tuple[int, int]]]
-    | Callable[[TextIO, bool], Generator[line_info, None, tuple[int, int]]]
-):
+) -> Callable:
     """
     Return a C or Fortran line source for path depending on
     the language we can detect, or fail.

--- a/codebasin/file_source.py
+++ b/codebasin/file_source.py
@@ -4,9 +4,12 @@
 Contains classes and functions for stripping comments and whitespace from
 C/C++ files as well as fixed-form Fortran
 """
+from __future__ import annotations
 
 import itertools as it
 import logging
+from collections.abc import Callable, Generator, Iterable, Iterator
+from typing import Any, TextIO
 
 from codebasin.language import FileLanguage
 
@@ -19,11 +22,14 @@ class one_space_line:
     merging all whitespace into a single space.
     """
 
-    def __init__(self):
-        self.parts = []
+    def __init__(self) -> None:
+        self.reset()
+
+    def reset(self) -> None:
+        self.parts: list[str] = []
         self.trailing_space = False
 
-    def append_char(self, c):
+    def append_char(self, c: str) -> None:
         """
         Append a character of no particular class to the line.
         Whitespace will be dropped if the line already ends in space.
@@ -36,7 +42,7 @@ class one_space_line:
                 self.parts.append(" ")
                 self.trailing_space = True
 
-    def append_space(self):
+    def append_space(self) -> None:
         """
         Append whitespace to line, unless line already ends in a space.
         """
@@ -44,11 +50,11 @@ class one_space_line:
             self.parts.append(" ")
             self.trailing_space = True
 
-    def append_nonspace(self, c):
+    def append_nonspace(self, c: str) -> None:
         self.parts.append(c)
         self.trailing_space = False
 
-    def join(self, other):
+    def join(self, other: one_space_line) -> None:
         """
         Append another one_space_line to this one, respecting whitespace rules.
         """
@@ -59,7 +65,7 @@ class one_space_line:
                 self.parts += other.parts[:]
             self.trailing_space = other.trailing_space
 
-    def category(self):
+    def category(self) -> str:
         """
         Report the a category for this line:
         * SRC_NONBLANK if it is non-empty/non-whitespace line of code.
@@ -78,12 +84,12 @@ class one_space_line:
             res = "CPP_DIRECTIVE"
         return res
 
-    def flush(self):
+    def flush(self) -> str:
         """
         Convert the characters to a string and reset the buffer.
         """
         res = "".join(self.parts)
-        self.__init__()
+        self.reset()
         return res
 
 
@@ -93,21 +99,21 @@ class iter_keep1:
     and picked up for the next iteration.
     """
 
-    def __init__(self, iterator):
-        self.iterator = iter(iterator)
+    def __init__(self, iterable: Iterable) -> None:
+        self.iterator = iter(iterable)
         self.single = None
 
-    def __iter__(self):
+    def __iter__(self) -> iter_keep1:
         return self
 
-    def __next__(self):
+    def __next__(self) -> Any:
         if self.single is not None:
             res, self.single = self.single, None
             return res
         else:
             return next(self.iterator)
 
-    def putback(self, item):
+    def putback(self, item: Any) -> None:
         """
         Put item into the iterator such that it will be the next
         yielded item.
@@ -127,7 +133,11 @@ class c_cleaner:
     logical_newline.
     """
 
-    def __init__(self, outbuf, directives_only=False):
+    def __init__(
+        self,
+        outbuf: one_space_line,
+        directives_only: bool = False,
+    ) -> None:
         """
         directives_only has the cleaner only operate on directive lines.
         """
@@ -136,7 +146,7 @@ class c_cleaner:
         self.directives_only = directives_only
         self.iterkeep = iter_keep1("")
 
-    def logical_newline(self):
+    def logical_newline(self) -> None:
         """
         Reset state when a logical newline is found.
         That is, when a newline without continuation.
@@ -163,7 +173,7 @@ class c_cleaner:
         elif self.state[-1] == "CPP_DIRECTIVE":
             self.state = ["TOPLEVEL"]
 
-    def process(self, lineiter):
+    def process(self, lineiter: Iterator) -> None:
         """
         Add contents of lineiter to outbuf, stripping as directed.
         """
@@ -280,12 +290,12 @@ class fortran_cleaner:
     Expects to have c defines already processed.
     """
 
-    def __init__(self, outbuf):
+    def __init__(self, outbuf: one_space_line) -> None:
         self.state = ["TOPLEVEL"]
         self.outbuf = outbuf
-        self.verify_continue = []
+        self.verify_continue: list[str] = []
 
-    def dir_check(self, inbuffer):
+    def dir_check(self, inbuffer: iter_keep1) -> None:
         """
         Inspect comment to see if it is in fact, a valid directive,
         which should be preserved.
@@ -304,7 +314,7 @@ class fortran_cleaner:
             else:
                 return
 
-    def process(self, lineiter):
+    def process(self, lineiter: Iterator) -> None:
         """
         Add contents of lineiter to current line, removing contents and
         handling continuations.
@@ -398,16 +408,16 @@ class line_info:
     Reprsents a logical line of code.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.current_logical_line = one_space_line()
-        self.current_physical_start = 1
-        self.current_physical_end = None
-        self.lines = []
-        self.local_sloc = 0
-        self.category = None
-        self.flushed_line = None
+        self.current_physical_start: int = 1
+        self.current_physical_end: int | None = None
+        self.lines: list[int] = []
+        self.local_sloc: int = 0
+        self.category: str | None = None
+        self.flushed_line: str | None = None
 
-    def join(self, other_line):
+    def join(self, other_line: one_space_line) -> None:
         """
         Combine this logical line with another one.
         """
@@ -426,7 +436,7 @@ class line_info:
         """
         self.add_physical_lines([line])
 
-    def physical_update(self, physical_line_num):
+    def physical_update(self, physical_line_num: int) -> None:
         """
         Mark end of new physical line.
         """
@@ -434,10 +444,12 @@ class line_info:
         self.category = self.current_logical_line.category()
         self.flushed_line = self.current_logical_line.flush()
 
-    def physical_reset(self):
+    def physical_reset(self) -> int:
         """
         Prepare for next logical block. Return counted sloc.
         """
+        if self.current_physical_end is None:
+            raise ValueError("Unexpected current_physical_end.")
         self.current_physical_start = self.current_physical_end
         local_sloc_copy = self.local_sloc
         self.lines = []
@@ -445,22 +457,15 @@ class line_info:
         self.flushed_line = None
         return local_sloc_copy
 
-    def phys_interval(self):
+    def phys_interval(self) -> tuple[int, int | None]:
         return (self.current_physical_start, self.current_physical_end)
 
-    def logical_result(self):
-        """
-        Return tuple of contents. Eventually should just return this class.
-        """
-        return (
-            (self.current_physical_start, self.current_physical_end),
-            self.local_sloc,
-            self.flushed_line,
-            self.category,
-        )
 
-
-def c_file_source(fp, directives_only=False):
+def c_file_source(
+    fp: TextIO,
+    *,
+    directives_only: bool = False,
+) -> Generator[line_info, None, tuple[int, int]]:
     """
     Process file fp in terms of logical (sloc) and physical lines of C code.
     Yield blocks of logical lines of code with physical extents.
@@ -478,7 +483,7 @@ def c_file_source(fp, directives_only=False):
     physical_line_num = 0
     continued = False
     for physical_line_num, line in enumerate(fp, start=1):
-        current_physical_line.__init__()
+        current_physical_line.reset()
         end = len(line)
         if line[-1] == "\n":
             end -= 1
@@ -527,7 +532,9 @@ def c_file_source(fp, directives_only=False):
     return (total_sloc, total_physical_lines)
 
 
-def fortran_file_source(fp):
+def fortran_file_source(
+    fp: TextIO,
+) -> Generator[line_info, None, tuple[int, int]]:
     """
     Process file fp in terms of logical (sloc) and physical lines of
     fixed-form  Fortran code.
@@ -555,6 +562,8 @@ def fortran_file_source(fp):
                 current_physical_start = curr_line.current_physical_start
 
             if src_c_line.category == "CPP_DIRECTIVE":
+                if src_c_line.current_physical_end is None:
+                    raise ValueError("Unexpected current_physical_end.")
                 curr_line.physical_update(src_c_line.current_physical_end)
                 if curr_line.category != "BLANK":
                     yield curr_line
@@ -565,7 +574,10 @@ def fortran_file_source(fp):
                 total_sloc += src_c_line.local_sloc
                 continue
 
-            current_physical_line.__init__()
+            current_physical_line.reset()
+
+            if src_c_line.flushed_line is None:
+                raise ValueError("Unexpected flushed_line.")
             cleaner.process(
                 it.islice(
                     src_c_line.flushed_line,
@@ -581,6 +593,8 @@ def fortran_file_source(fp):
 
             if cleaner.state[-1] != "CONTINUING_FROM_SOL":
                 curr_line.current_physical_start = current_physical_start
+                if src_c_line.current_physical_end is None:
+                    raise ValueError("Unexpected current_physical_end.")
                 curr_line.physical_update(src_c_line.current_physical_end)
                 if curr_line.category != "BLANK":
                     yield curr_line
@@ -593,6 +607,8 @@ def fortran_file_source(fp):
 
     curr_line.physical_update(total_physical_lines)
     if not curr_line.category == "BLANK":
+        if current_physical_start is None:
+            raise ValueError("Unexpected current_physical_start.")
         curr_line.current_physical_start = current_physical_start
         yield curr_line
 
@@ -615,11 +631,11 @@ class asm_cleaner:
     Expects to have c defines already processed.
     """
 
-    def __init__(self, outbuf):
+    def __init__(self, outbuf: one_space_line) -> None:
         self.state = ["TOPLEVEL"]
         self.outbuf = outbuf
 
-    def process(self, lineiter):
+    def process(self, lineiter: Iterator) -> None:
         """
         Add contents of lineiter to current line
         """
@@ -649,7 +665,7 @@ class asm_cleaner:
             pass
 
 
-def asm_file_source(fp):
+def asm_file_source(fp: TextIO) -> Generator[line_info, None, tuple[int, int]]:
     """
     Process file fp in terms of logical (sloc) and physical lines of ASM code.
     Yield blocks of logical lines of code with physical extents.
@@ -665,7 +681,7 @@ def asm_file_source(fp):
 
     physical_line_num = 0
     for physical_line_num, line in enumerate(fp, start=1):
-        current_physical_line.__init__()
+        current_physical_line.reset()
         end = len(line)
         if line[-1] == "\n":
             end -= 1
@@ -693,7 +709,14 @@ def asm_file_source(fp):
     return (total_sloc, total_physical_lines)
 
 
-def get_file_source(path, assumed_lang=None):
+# FIXME: The return type of this function suggests it is too complicated.
+def get_file_source(
+    path: str,
+    assumed_lang: str | None = None,
+) -> (
+    Callable[[TextIO], Generator[line_info, None, tuple[int, int]]]
+    | Callable[[TextIO, bool], Generator[line_info, None, tuple[int, int]]]
+):
     """
     Return a C or Fortran line source for path depending on
     the language we can detect, or fail.

--- a/codebasin/language.py
+++ b/codebasin/language.py
@@ -51,7 +51,7 @@ class FileLanguage:
     ]
     _language_extensions["asm"] = [".s", ".S", ".asm"]
 
-    def __init__(self, filename):
+    def __init__(self, filename: str):
         self._filename = filename
         self._extension = os.path.splitext(self._filename)[1]
         self._language = None
@@ -61,5 +61,5 @@ class FileLanguage:
                 self._language = lang
                 break
 
-    def get_language(self):
+    def get_language(self) -> str | None:
         return self._language

--- a/codebasin/platform.py
+++ b/codebasin/platform.py
@@ -7,6 +7,8 @@ options for a specific platform.
 
 import os
 
+from codebasin.preprocessor import Macro, MacroFunction
+
 
 class Platform:
     """
@@ -14,29 +16,29 @@ class Platform:
     Contains a list of definitions, and include paths.
     """
 
-    def __init__(self, name, _root_dir):
-        self._definitions = {}
-        self._skip_includes = []
-        self._include_paths = []
+    def __init__(self, name: str, _root_dir: str) -> None:
+        self._definitions: dict[str, Macro | MacroFunction] = {}
+        self._skip_includes: list[str] = []
+        self._include_paths: list[str] = []
         self._root_dir = _root_dir
         self.name = name
-        self.found_incl = {}
+        self.found_incl: dict[str, str | None] = {}
 
-    def add_include_path(self, path):
+    def add_include_path(self, path: str) -> None:
         """
         Insert a new path into the list of include paths for this
         platform.
         """
         self._include_paths.append(path)
 
-    def undefine(self, identifier):
+    def undefine(self, identifier: str) -> None:
         """
         Undefine a macro for this platform, if it's defined.
         """
         if identifier in self._definitions:
             del self._definitions[identifier]
 
-    def define(self, identifier, macro):
+    def define(self, identifier: str, macro: Macro | MacroFunction) -> None:
         """
         Define a new macro for this platform, only if it's not already
         defined.
@@ -44,7 +46,7 @@ class Platform:
         if identifier not in self._definitions:
             self._definitions[identifier] = macro
 
-    def add_include_to_skip(self, fn):
+    def add_include_to_skip(self, fn: str) -> None:
         """
         Define a new macro for this platform, only if it's not already
         defined.
@@ -52,23 +54,24 @@ class Platform:
         if fn not in self._skip_includes:
             self._skip_includes.append(fn)
 
-    def process_include(self, fn):
+    def process_include(self, fn: str) -> bool:
         """
         Return a boolean stating if this include file should be
         processed or skipped.
         """
         return fn not in self._skip_includes
 
-    def is_defined(self, identifier):
+    # FIXME: This should return a bool, but the usage relies on a str.
+    def is_defined(self, identifier: str) -> str:
         """
-        Return a boolean stating if the macro named by 'identifier' is
+        Return a string representing whether the macro named by 'identifier' is
         defined.
         """
         if identifier in self._definitions:
             return "1"
         return "0"
 
-    def get_macro(self, identifier):
+    def get_macro(self, identifier: str) -> Macro | MacroFunction | None:
         """
         Return either a macro definition (if it's defined), or None.
         """
@@ -76,7 +79,12 @@ class Platform:
             return self._definitions[identifier]
         return None
 
-    def find_include_file(self, filename, this_path, is_system_include=False):
+    def find_include_file(
+        self,
+        filename: str,
+        this_path: str,
+        is_system_include: bool = False,
+    ) -> str | None:
         """
         Determine and return the full path to an include file, named
         'filename' using the include paths for this platform.
@@ -103,6 +111,7 @@ class Platform:
                 self.found_incl[filename] = include_file
                 return include_file
 
-        if include_file is None:
-            self.found_incl[filename] = None
-            return None
+        # TODO: Check this optimization is always valid.
+        assert include_file is None
+        self.found_incl[filename] = None
+        return None

--- a/codebasin/platform.py
+++ b/codebasin/platform.py
@@ -112,6 +112,7 @@ class Platform:
                 return include_file
 
         # TODO: Check this optimization is always valid.
-        assert include_file is None
+        if include_file is not None:
+            raise RuntimeError("Expected 'None', got '{filename}'")
         self.found_incl[filename] = None
         return None

--- a/codebasin/preprocessor.py
+++ b/codebasin/preprocessor.py
@@ -619,7 +619,7 @@ class CodeNode(Node):
     start_line: int = field(default=-1, init=False)
     end_line: int = field(default=-1, init=False)
     num_lines: int = field(default=0, init=False)
-    source: str | None = field(default=None, init=False, repr=False)
+    source: list[str] | None = field(default=None, init=False, repr=False)
     lines: list[int] | None = field(
         default_factory=list,
         init=False,
@@ -631,7 +631,7 @@ class CodeNode(Node):
         start_line: int = -1,
         end_line: int = -1,
         num_lines: int = 0,
-        source: str | None = None,
+        source: list[str] | None = None,
         lines: list[int] | None = None,
     ):
         super().__init__()

--- a/codebasin/tree.py
+++ b/codebasin/tree.py
@@ -97,7 +97,7 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _tree(args: argparse.Namespace):
+def _tree(args: argparse.Namespace) -> None:
     # Refuse to print a tree with no levels, consistent with tree utility.
     if args.levels is not None and args.levels <= 0:
         raise ValueError("Number of levels must be greater than 0.")
@@ -158,7 +158,7 @@ def _tree(args: argparse.Namespace):
     sys.exit(0)
 
 
-def cli(argv: list[str]) -> int:
+def cli(argv: list[str]) -> None:
     parser = _build_parser()
     args = parser.parse_args(argv)
 
@@ -171,10 +171,10 @@ def cli(argv: list[str]) -> int:
     stderr_handler.setFormatter(Formatter(colors=sys.stderr.isatty()))
     log.addHandler(stderr_handler)
 
-    return _tree(args)
+    _tree(args)
 
 
-def main():
+def main() -> None:
     try:
         cli(sys.argv[1:])
     except Exception as e:

--- a/tests/files/test_filetree_node.py
+++ b/tests/files/test_filetree_node.py
@@ -44,7 +44,7 @@ class TestFileTreeNode(unittest.TestCase):
         self.assertEqual(node.children, dict())
         self.assertFalse(node.is_root)
         self.assertEqual(node.name, self.path.name)
-        self.assertEqual(node.platforms, [])
+        self.assertEqual(node.platforms, set())
         self.assertEqual(node.sloc, 0)
         self.assertTrue(node.is_dir())
         self.assertFalse(node.is_symlink())


### PR DESCRIPTION
# Related issues

- Closes #182, @laserkelvin.

# Proposed changes

- Configure `mypy` to check for missing type hints in addition to type errors.
- Add type hints to (almost) all functions, with one exception due to complexity.
- Make minimal code changes to satisfy `mypy`.

---

I'm sorry that this is so big, but I realized early on that doing this file by file didn't really work (even though the commit history suggests it did).  Adding type hints to one file would often cause `mypy` to go back and re-examine the code that called those functions, potentially introducing a bunch of new errors.

But I think this was worth it, and the code is now much improved.  There were quite a few places where adding the type information actually uncovered some bugs (or at least, assumptions) such as assuming that a function returns a value even though it's technically capable of returning `None`.  For the most part, I've satisfied `mypy` by declaring which functions can sometimes return `None`, and then adding checks that they don't.

In the long-term, I would like to revisit some of the problems that this change has highlighted, including:
- Rewriting code to avoid `| None`, by preventing invalid look-ups entirely.
- Rewriting functions to avoid complex nested type definitions (e.g., dicts of lists of tuples of lists...)
- Rewriting `file_source` (see #102) to avoid all the complexity related to the file-source `Callable`s.
- Move `Platform` into the `Preprocessor` so that we can use strong-typing without introducing a circular import.